### PR TITLE
Refactor DataGenerator to support shuffled datasets

### DIFF
--- a/OptimizedDataGeneratorNew.py
+++ b/OptimizedDataGeneratorNew.py
@@ -1,0 +1,416 @@
+import os
+import gc
+import math
+import glob
+import random
+import logging
+import datetime
+import numpy as np
+import pandas as pd
+
+from typing import Union, List, Tuple
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_completed
+
+from tqdm import tqdm
+import tensorflow as tf
+from qkeras import quantized_bits
+
+import utils
+
+
+# custom quantizer
+
+# @tf.function
+def QKeras_data_prep_quantizer(data, bits=4, int_bits=0, alpha=1):
+    """
+    Applies QKeras quantization.
+    Args:
+        data (tf.Tensor): Input data (tf.Tensor).
+        bits (int): Number of bits for quantization.
+        int_bits (int): Number of integer bits.
+        alpha (float): (don't change)
+    Returns::
+        tf.Tensor: Quantized data (tf.Tensor).
+    """
+    quantizer = quantized_bits(bits, int_bits, alpha=alpha)
+    return quantizer(data)
+
+
+def split_df_to_X_y_df(df: pd.DataFrame,
+                       input_shape: Tuple[int, int, int],
+                       labels_list: List[str],
+                       recon_cols: List[int]) -> Tuple[pd.DataFrame, pd.DataFrame]:
+
+    X_df = df[recon_cols].copy()
+    y_df = df[labels_list].copy()
+
+    return X_df, y_df
+
+
+
+class OptimizedDataGenerator(tf.keras.utils.Sequence):
+    def __init__(self, 
+            dataset_base_dir: str = "./",
+            is_directory_recursive: bool = False,
+            batch_size: int = 32,
+            file_count = None,
+            labels_list: Union[List,str] = "cotAlpha",
+            to_standardize: bool = False,
+            input_shape: Tuple = (13,21),
+            transpose = None,
+            include_y_local: bool = False,
+            files_from_end = False,
+            shuffle=False,
+
+            # Added in Optimized datagenerators 
+            load_from_tfrecords_dir: str = None,
+            tfrecords_dir: str = None,
+            use_time_stamps = -1,
+            seed: int = None,
+            quantize: bool = False,
+            max_workers: int = 1,
+                 
+            **kwargs,
+            ):
+        super().__init__() 
+
+        self.shuffle = shuffle
+        if shuffle:
+            self.seed = seed if seed is not None else 13
+            self.rng = np.random.default_rng(seed = self.seed)
+        
+        # If data is already prepared load anduse that data
+        if load_from_tfrecords_dir is not None:
+            self.file_offsets = [None]
+            if not os.path.isdir(load_from_tfrecords_dir):
+                raise ValueError(f"Directory {load_from_tfrecords_dir} does not exist.")
+            else:
+                self.tfrecords_dir = load_from_tfrecords_dir
+        else:
+            n_time, height, width = input_shape
+            assert len(use_time_stamps) == n_time, f"Expected {n_time} time steps, got {len(use_time_stamps)}"
+    
+            len_xy = height * width
+            col_indices = [
+                np.arange(t * len_xy, (t + 1) * len_xy).astype(str)
+                for t in use_time_stamps
+            ]
+            self.use_time_stamps = np.arange(0,20) if use_time_stamps == -1 else use_time_stamps
+            self.recon_cols = np.concatenate(col_indices).tolist()
+    
+    
+    
+            self.max_workers = max_workers
+            self.shuffle = shuffle
+
+            
+            self.files = sorted(glob.glob(os.path.join(dataset_base_dir, "part.*.parquet"), recursive=False))
+    
+            if file_count != None:
+                if not files_from_end:
+                    self.files = self.files[:file_count]
+                else:
+                    self.files = self.files[-file_count:]
+    
+    
+            self.file_offsets = [0]
+            self.dataset_mean = None
+            self.dataset_std = None
+
+            # safe_remove_directory(tfrecords_dir)
+            utils.safe_remove_directory(tfrecords_dir)
+            self.batch_size = batch_size
+            self.labels_list = labels_list
+            self.input_shape = input_shape
+            self.transpose = transpose
+            self.to_standardize = to_standardize
+            self.include_y_local = include_y_local
+
+            self.process_file_parallel()
+    
+            self.current_file_index = None
+            self.current_dataframes = None
+    
+            if tfrecords_dir is None:
+                raise ValueError(f"tfrecords_dir is None")
+                
+            self.tfrecords_dir = tfrecords_dir    
+            os.makedirs(self.tfrecords_dir, exist_ok=True)
+            self.save_batches_parallel() # save all the batches
+            del self.current_dataframes 
+            
+        self.tfrecord_filenames = np.sort(np.array(tf.io.gfile.glob(os.path.join(self.tfrecords_dir, "*.tfrecord"))))
+        self.quantize = quantize
+        self.epoch_count = 0
+        self.on_epoch_end()
+
+
+    def process_file_parallel(self):
+        file_infos = [(afile, self.recon_cols, self.input_shape, self.transpose, self.labels_list) for afile in self.files]
+        results = []
+        with ProcessPoolExecutor(self.max_workers) as executor:
+            futures = [executor.submit(self._process_file_single, file_info) for file_info in file_infos]
+            for future in tqdm(as_completed(futures), total=len(file_infos), desc="Processing Files..."):
+                results.append(future.result())
+
+        for amean, avariance, amin, amax, num_rows in results:
+            self.file_offsets.append(self.file_offsets[-1] + num_rows)
+
+            if self.dataset_mean is None:
+                self.dataset_max = amax
+                self.dataset_min = amin
+                self.dataset_mean = amean
+                self.dataset_std = avariance
+            else:
+                self.dataset_max = max(self.dataset_max, amax)
+                self.dataset_min = min(self.dataset_min, amin)
+                self.dataset_mean += amean
+                self.dataset_std += avariance
+
+        self.dataset_mean = self.dataset_mean / len(self.files)
+        self.dataset_std = np.sqrt(self.dataset_std / len(self.files)) 
+            
+        self.file_offsets = np.array(self.file_offsets)
+
+    @staticmethod
+    def _process_file_single(file_info):
+        afile, recon_cols, input_shape, transpose, labels_list = file_info
+        df = pd.read_parquet(afile, columns=recon_cols + labels_list)
+        adf, _ = split_df_to_X_y_df(df, input_shape, labels_list, recon_cols)
+
+        x = adf.values
+        nonzeros = abs(x) > 0
+        x[nonzeros] = np.sign(x[nonzeros]) * np.log1p(abs(x[nonzeros])) / math.log(2)
+        amean, avariance = np.mean(x[nonzeros], keepdims=True), np.var(x[nonzeros], keepdims=True) + 1e-10
+        centered = np.zeros_like(x)
+        centered[nonzeros] = (x[nonzeros] - amean) / np.sqrt(avariance)
+        x = x.reshape((-1, *input_shape))
+        if transpose is not None:
+            x = x.transpose(transpose)
+        amin, amax = np.min(centered), np.max(centered)
+        len_adf = len(adf)
+        del adf
+        gc.collect()
+        
+        return amean, avariance, amin, amax, len_adf
+
+    def standardize(self, x, norm_factor_pos=1.7, norm_factor_neg=2.5):
+        """
+        Applies the normalization configuration in-place to a batch of inputs.
+        `x` is changed in-place since the function is mainly used internally
+        to standardize images and feed them to your network.
+        Args:
+            x: Batch of inputs to be normalized.
+        Returns:
+            The inputs, normalized. 
+        """
+        out = (x - self.dataset_mean)/self.dataset_std
+        out[out > 0] = out[out > 0]/norm_factor_pos
+        out[out < 0] = out[out < 0]/norm_factor_neg
+        return out
+
+    def save_batches_parallel(self):
+        """
+        Saves data batches as multiple TFRecord files.
+        """
+        # TODO: Make this parallelized
+        num_batches = self.__len__() # Total num of batches
+        paths_or_errors = []
+
+        # The max_workers is set to 1 because processing large batches in multiple threads can significantly
+        # increase RAM usage. Adjust 'max_workers' based on your system's RAM capacity and requirements.
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            future_to_batch = {executor.submit(self.save_single_batch, i): i for i in range(num_batches)}
+            
+            for future in tqdm(as_completed(future_to_batch), total=num_batches, desc="Saving batches as TFRecords"):
+                result = future.result()
+                paths_or_errors.append(result)
+            
+        for res in paths_or_errors:
+            if "Error" in res:
+                print(res)  
+                
+    def save_single_batch(self, batch_index):
+        """
+        Serializes and saves a single batch to a TFRecord file.
+        Args:
+            batch_index (int): Index of the batch to save.
+        Returns:
+            str: Path to the saved TFRecord file or an error message.
+        """
+        
+        try:
+            filename = f"batch_{batch_index}.tfrecord"
+            TFRfile_path = os.path.join(self.tfrecords_dir, filename)
+            X, y = self.prepare_batch_data(batch_index)
+            serialized_example = self.serialize_example(X, y)
+            with tf.io.TFRecordWriter(TFRfile_path) as writer:
+                writer.write(serialized_example)
+            return TFRfile_path
+        except Exception as e:
+            return f"Error saving batch {batch_index}: {e}" 
+        
+    def prepare_batch_data(self, batch_index):
+        """
+        Fetch and prepare one batch (X, y).
+        """
+        abs_idx = batch_index * self.batch_size
+        file_idx = (np.arange(self.file_offsets.size)[abs_idx < self.file_offsets][0] - 1)
+        rel_idx = abs_idx - self.file_offsets[file_idx]
+        stop_idx = min(rel_idx + self.batch_size, self.file_offsets[file_idx + 1] - self.file_offsets[file_idx])
+
+        if file_idx != self.current_file_index:
+            self.current_file_index = file_idx
+            parquet_file = self.files[file_idx]
+
+            all_columns_to_read = self.recon_cols + self.labels_list
+            df = pd.read_parquet(parquet_file, columns=all_columns_to_read)
+
+            # df = pd.read_parquet(parquet_file, columns=self.use_time_stamps)
+            recon_df, labels_df = split_df_to_X_y_df(df, self.input_shape, self.labels_list, self.recon_cols)
+
+            has_nans = np.any(np.isnan(recon_df.values), axis=1)
+            has_nans = np.arange(recon_df.shape[0])[has_nans]
+            recon_df_raw = recon_df.drop(has_nans)
+            labels_df_raw = labels_df.drop(has_nans)
+
+            joined_df = recon_df_raw.join(labels_df_raw)
+
+            if self.shuffle: # Changed
+                joined_df = joined_df.sample(frac=1, random_state=self.seed).reset_index(drop=True)  
+
+            recon_values = joined_df[recon_df_raw.columns].values            
+
+            nonzeros = abs(recon_values) > 0
+            
+            recon_values[nonzeros] = np.sign(recon_values[nonzeros])*np.log1p(abs(recon_values[nonzeros]))/math.log(2)
+            
+            if self.to_standardize:
+                recon_values[nonzeros] = self.standardize(recon_values[nonzeros])
+            
+            recon_values = recon_values.reshape((-1, *self.input_shape))            
+                        
+            if self.transpose is not None:
+                recon_values = recon_values.transpose(self.transpose)
+            
+            self.current_dataframes = (
+                recon_values, 
+                joined_df[labels_df_raw.columns].values,
+            )        
+        
+        recon_df, labels_df = self.current_dataframes
+
+        X = recon_df[rel_idx:stop_idx]
+        y = labels_df[rel_idx:stop_idx] / np.array([75., 18.75, 8.0, 0.5])
+    
+        if self.include_y_local:
+            y_local = labels_df.iloc[chosen_idxs]["y-local"].values
+            return [X, y_local], y
+        else:
+            return X, y
+    
+    def serialize_example(self, X, y):
+        """
+        Serializes a single example (featuresand labels) to TFRecord format. 
+        
+        Args:
+        - X: Training data
+        - y: labelled data
+        
+        Returns:
+        - string (serialized TFRecord example).
+        """
+        # X and y are float32 (maybe we can reduce this)
+        X = tf.cast(X, tf.float32)
+        y = tf.cast(y, tf.float32)
+
+        feature = {
+            'X': self._bytes_feature(tf.io.serialize_tensor(X)),
+            'y': self._bytes_feature(tf.io.serialize_tensor(y)),
+        }
+        example_proto = tf.train.Example(features=tf.train.Features(feature=feature))
+        return example_proto.SerializeToString()
+
+    @staticmethod
+    def _bytes_feature(value):
+        """
+        Converts a string/byte value into a Tf feature of bytes_list
+        
+        Args: 
+        - string/byte value
+        
+        Returns:
+        - tf.train.Feature object as a bytes_list containing the input value.
+        """
+        if isinstance(value, type(tf.constant(0))): # check if Tf tensor
+            value = value.numpy()
+        return tf.train.Feature(bytes_list=tf.train.BytesList(value=[value]))
+
+    def __getitem__(self, batch_index):
+        """
+        Load the batch from a pre-saved TFRecord file instead of processing raw data.
+        Each file contains exactly one batch.
+        quantization is done here: Helpful for pretraining without the quantization and the later training with quantized data.
+        shuffling is also done here.
+        TODO: prefetching (un-done)
+        """
+        tfrecord_path = self.tfrecord_filenames[batch_index]
+        raw_dataset = tf.data.TFRecordDataset(tfrecord_path)
+        parsed_dataset = raw_dataset.map(self._parse_tfrecord_fn, num_parallel_calls=tf.data.AUTOTUNE)
+
+        for X_batch, y_batch in parsed_dataset:
+            ''' Add the reshaping in saving'''
+            X_batch = tf.reshape(X_batch, [-1, *X_batch.shape[1:]])
+            y_batch = tf.reshape(y_batch, [-1, *y_batch.shape[1:]])
+
+            if self.quantize:
+                X_batch = QKeras_data_prep_quantizer(X_batch, bits=4, int_bits=0, alpha=1)
+
+            if self.shuffle:
+                indices = tf.range(start=0, limit=tf.shape(X_batch)[0], dtype=tf.int32)
+                shuffled_indices = tf.random.shuffle(indices, seed=self.seed)
+                X_batch = tf.gather(X_batch, shuffled_indices)
+                y_batch = tf.gather(y_batch, shuffled_indices)
+                
+            del raw_dataset, parsed_dataset
+            return X_batch, y_batch
+            
+    @staticmethod
+    def _parse_tfrecord_fn(example):
+        """
+        Parses a single TFRecord example.
+        
+        Returns:
+        - X: as a float32 tensor.
+        - y: as a float32 tensor.
+        """
+        feature_description = {
+            'X': tf.io.FixedLenFeature([], tf.string),
+            'y': tf.io.FixedLenFeature([], tf.string),
+        }
+        example = tf.io.parse_single_example(example, feature_description)
+        X = tf.io.parse_tensor(example['X'], out_type=tf.float32)
+        y = tf.io.parse_tensor(example['y'], out_type=tf.float32)
+        return X, y
+
+    def __len__(self):
+        if len(self.file_offsets) != 1: # used when TFRecord files are created during initialization
+            num_batches = self.file_offsets[-1] // self.batch_size
+        else: # used during loading saved TFRecord files
+            num_batches = len(os.listdir(self.tfrecords_dir))
+        return num_batches
+
+    def on_epoch_end(self):
+        '''
+        This shuffles the file ordering so that it shuffles the ordering in which the TFRecord
+        are loaded during the training for each epochs.
+        '''
+        gc.collect()
+        self.epoch_count += 1
+        # Log quantization status once
+        if self.epoch_count == 1:
+            logging.warning(f"Quantization is {self.quantize} in data generator. This may affect model performance.")
+
+        if self.shuffle:
+            self.rng.shuffle(self.tfrecord_filenames)
+            self.seed += 1 # So that after each epoch the batch is shuffled with a different seed (deterministic)

--- a/train_model_new_example.ipynb
+++ b/train_model_new_example.ipynb
@@ -1,0 +1,515 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "24773cdc-4bbe-48c3-9910-8b39c38bfc7a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-05-12 14:48:27.825389: E external/local_xla/xla/stream_executor/cuda/cuda_dnn.cc:9261] Unable to register cuDNN factory: Attempting to register factory for plugin cuDNN when one has already been registered\n",
+      "2025-05-12 14:48:27.825469: E external/local_xla/xla/stream_executor/cuda/cuda_fft.cc:607] Unable to register cuFFT factory: Attempting to register factory for plugin cuFFT when one has already been registered\n",
+      "2025-05-12 14:48:27.826540: E external/local_xla/xla/stream_executor/cuda/cuda_blas.cc:1515] Unable to register cuBLAS factory: Attempting to register factory for plugin cuBLAS when one has already been registered\n",
+      "2025-05-12 14:48:27.835297: I tensorflow/core/platform/cpu_feature_guard.cc:182] This TensorFlow binary is optimized to use available CPU instructions in performance-critical operations.\n",
+      "To enable the following instructions: AVX2 FMA, in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
+      "2025-05-12 14:48:28.707486: W tensorflow/compiler/tf2tensorrt/utils/py_utils.cc:38] TF-TRT Warning: Could not find TensorRT\n"
+     ]
+    }
+   ],
+   "source": [
+    "import tensorflow as tf\n",
+    "from tensorflow.keras import datasets, layers, models\n",
+    "from tensorflow.keras.optimizers import Adam\n",
+    "import keras\n",
+    "from keras.models import Sequential, Model\n",
+    "from keras.layers import *\n",
+    "from keras.utils import Sequence\n",
+    "from keras.layers import Conv2D, MaxPooling2D\n",
+    "from qkeras import *\n",
+    "\n",
+    "from keras.utils import Sequence\n",
+    "from keras.callbacks import CSVLogger\n",
+    "from keras.callbacks import EarlyStopping\n",
+    "\n",
+    "import os\n",
+    "import random\n",
+    "from datetime import datetime\n",
+    "import time\n",
+    "\n",
+    "pi = 3.14159265359\n",
+    "\n",
+    "maxval=1e9\n",
+    "minval=1e-9"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "1ac065e8-fcf2-44a0-8dee-e1e44e605137",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#from dataprep import *\n",
+    "from OptimizedDataGeneratorNew import OptimizedDataGenerator\n",
+    "from loss import *\n",
+    "from models import *\n",
+    "import mdmm\n",
+    "\n",
+    "tfd = tfp.distributions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "ff499d81-383f-4988-94d7-12815179e089",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "bfbc64d0-998a-4022-b4f5-e886c4c07941",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset_base_dir = \"/depot/cms/users/das214/datasets/dataset_3sr/dataset_3sr_50x12P5_parquets/unflipped\"\n",
+    "tfrecords_base_dir = os.path.join(dataset_base_dir, \"TFR_files\", \"2t\")\n",
+    "\n",
+    "dataset_base_dir = os.path.join(dataset_base_dir, \"recon3D\")\n",
+    "tfrecords_dir_train = os.path.join(tfrecords_base_dir, \"TFR_train\")\n",
+    "tfrecords_dir_val   = os.path.join(tfrecords_base_dir, \"TFR_val\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "80c17a48-9308-40e4-a126-5478659cfedd",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "100"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(os.listdir(dataset_base_dir))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "af8bb9b7-c75e-489d-83bc-ad517c652aab",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "batch_size = 5000\n",
+    "val_batch_size = 5000\n",
+    "train_file_size = 75\n",
+    "val_file_size = 25"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "66491533-15ba-4337-917e-8f99508cf3bd",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Directory /depot/cms/users/das214/datasets/dataset_3sr/dataset_3sr_50x12P5_parquets/unflipped/TFR_files/2t/TFR_val is removed...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing Files...: 100%|██████████| 25/25 [00:08<00:00,  2.92it/s]\n",
+      "Saving batches as TFRecords:   0%|          | 0/98 [00:00<?, ?it/s]2025-05-12 14:48:41.073063: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1929] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 3234 MB memory:  -> device: 0, name: NVIDIA A100-PCIE-40GB MIG 1g.5gb, pci bus id: 0000:81:00.0, compute capability: 8.0\n",
+      "Saving batches as TFRecords: 100%|██████████| 98/98 [00:42<00:00,  2.31it/s]\n",
+      "WARNING:root:Quantization is False in data generator. This may affect model performance.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- Validation generator 51.342692852020264 seconds ---\n"
+     ]
+    }
+   ],
+   "source": [
+    "start_time = time.time()\n",
+    "validation_generator = OptimizedDataGenerator(\n",
+    "    dataset_base_dir = dataset_base_dir,\n",
+    "    file_type = \"parquet\",\n",
+    "    data_format = \"3D\",\n",
+    "    batch_size = val_batch_size,\n",
+    "    file_count = val_file_size,\n",
+    "    to_standardize= True,\n",
+    "    include_y_local= False,\n",
+    "    labels_list = ['x-midplane','y-midplane','cotAlpha','cotBeta'],\n",
+    "    input_shape = (2,13,21), # (20,13,21),\n",
+    "    transpose = (0,2,3,1),\n",
+    "    shuffle = False, \n",
+    "    files_from_end=True,\n",
+    "\n",
+    "    tfrecords_dir = tfrecords_dir_val,\n",
+    "    use_time_stamps = [0, 19], #-1\n",
+    "    max_workers = 2\n",
+    ")\n",
+    "\n",
+    "print(\"--- Validation generator %s seconds ---\" % (time.time() - start_time))\n",
+    "\n",
+    "# validation_generator.debug()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "dccba057-7aa7-4b85-95bd-8977c14cf7ea",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Directory /depot/cms/users/das214/datasets/dataset_3sr/dataset_3sr_50x12P5_parquets/unflipped/TFR_files/2t/TFR_train is removed...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing Files...: 100%|██████████| 75/75 [00:24<00:00,  3.12it/s]\n",
+      "Saving batches as TFRecords: 100%|██████████| 294/294 [01:03<00:00,  4.62it/s]\n",
+      "WARNING:root:Quantization is False in data generator. This may affect model performance.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- Training generator 88.1314115524292 seconds ---\n"
+     ]
+    }
+   ],
+   "source": [
+    "# training generator\n",
+    "start_time = time.time()\n",
+    "training_generator = OptimizedDataGenerator(\n",
+    "    dataset_base_dir = dataset_base_dir,\n",
+    "    file_type = \"parquet\",\n",
+    "    data_format = \"3D\",\n",
+    "    batch_size = batch_size,\n",
+    "    file_count = train_file_size,\n",
+    "    to_standardize= True,\n",
+    "    include_y_local= False,\n",
+    "    labels_list = ['x-midplane','y-midplane','cotAlpha','cotBeta'],\n",
+    "    input_shape = (2,13,21), # (20,13,21),\n",
+    "    transpose = (0,2,3,1),\n",
+    "    shuffle = False, # True \n",
+    "\n",
+    "    tfrecords_dir = tfrecords_dir_train,\n",
+    "    use_time_stamps = [0, 19], #-1\n",
+    "    max_workers = 2\n",
+    ")\n",
+    "print(\"--- Training generator %s seconds ---\" % (time.time() - start_time))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "248e5d17-2a8f-4e8c-871a-65a0ab3794b4",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:root:Quantization is True in data generator. This may affect model performance.\n",
+      "WARNING:root:Quantization is True in data generator. This may affect model performance.\n"
+     ]
+    }
+   ],
+   "source": [
+    "training_generator = OptimizedDataGenerator(\n",
+    "    load_from_tfrecords_dir = tfrecords_dir_train,\n",
+    "    shuffle = True,\n",
+    "    seed = 13,\n",
+    "    quantize = True\n",
+    ")\n",
+    "\n",
+    "validation_generator = OptimizedDataGenerator(\n",
+    "    load_from_tfrecords_dir = tfrecords_dir_val,\n",
+    "    shuffle = True,\n",
+    "    seed = 13,\n",
+    "    quantize = True\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "c72cef1b-61db-489f-83bb-039a46861094",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-05-12 14:50:52.263879: I external/local_tsl/tsl/platform/default/subprocess.cc:304] Start cannot spawn child process: No such file or directory\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Model: \"model\"\n",
+      "_________________________________________________________________\n",
+      " Layer (type)                Output Shape              Param #   \n",
+      "=================================================================\n",
+      " input_1 (InputLayer)        [(None, 13, 21, 2)]       0         \n",
+      "                                                                 \n",
+      " q_separable_conv2d (QSepar  (None, 11, 19, 5)         33        \n",
+      " ableConv2D)                                                     \n",
+      "                                                                 \n",
+      " q_activation (QActivation)  (None, 11, 19, 5)         0         \n",
+      "                                                                 \n",
+      " q_conv2d (QConv2D)          (None, 11, 19, 5)         30        \n",
+      "                                                                 \n",
+      " q_activation_1 (QActivatio  (None, 11, 19, 5)         0         \n",
+      " n)                                                              \n",
+      "                                                                 \n",
+      " average_pooling2d (Average  (None, 3, 6, 5)           0         \n",
+      " Pooling2D)                                                      \n",
+      "                                                                 \n",
+      " q_activation_2 (QActivatio  (None, 3, 6, 5)           0         \n",
+      " n)                                                              \n",
+      "                                                                 \n",
+      " flatten (Flatten)           (None, 90)                0         \n",
+      "                                                                 \n",
+      " q_dense (QDense)            (None, 16)                1456      \n",
+      "                                                                 \n",
+      " q_activation_3 (QActivatio  (None, 16)                0         \n",
+      " n)                                                              \n",
+      "                                                                 \n",
+      " q_dense_1 (QDense)          (None, 16)                272       \n",
+      "                                                                 \n",
+      " q_activation_4 (QActivatio  (None, 16)                0         \n",
+      " n)                                                              \n",
+      "                                                                 \n",
+      " q_dense_2 (QDense)          (None, 14)                238       \n",
+      "                                                                 \n",
+      "=================================================================\n",
+      "Total params: 2029 (7.93 KB)\n",
+      "Trainable params: 2029 (7.93 KB)\n",
+      "Non-trainable params: 0 (0.00 Byte)\n",
+      "_________________________________________________________________\n"
+     ]
+    }
+   ],
+   "source": [
+    "model=CreateModel((13,21,2),n_filters=5,pool_size=3)\n",
+    "model.compile(\n",
+    "    optimizer=tf.keras.optimizers.Nadam(learning_rate=1e-3),\n",
+    "    loss=custom_loss\n",
+    ")\n",
+    "\n",
+    "model.summary()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "ce60b630-5e1e-41cd-b9a0-7e9a06e9a395",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "\n",
+    "fingerprint = '%08x' % random.randrange(16**8)\n",
+    "timestamp = datetime.now().strftime('%Y%m%d-%H%M%S')\n",
+    "os.makedirs(\"trained_models\", exist_ok=True)\n",
+    "base_dir = f'./trained_models/model-{fingerprint}-checkpoints'\n",
+    "os.makedirs(base_dir, exist_ok=True)  \n",
+    "checkpoint_filepath = base_dir + '/weights.{epoch:02d}-t{loss:.2f}-v{val_loss:.2f}.hdf5'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "0ccc68b0-0d5a-4b14-bebc-0d8e6923e178",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "736e822b\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(fingerprint)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "dd97cbbf-a137-4a5c-9796-11de00abfa7f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from tensorflow.keras.callbacks import CSVLogger, EarlyStopping, ModelCheckpoint, Callback\n",
+    "\n",
+    "early_stopping_patience = 50\n",
+    "\n",
+    "class CustomModelCheckpoint(ModelCheckpoint):\n",
+    "    def on_epoch_end(self, epoch, logs=None):\n",
+    "        super().on_epoch_end(epoch, logs)\n",
+    "        checkpoints = [f for f in os.listdir(base_dir) if f.startswith('weights')]\n",
+    "        if len(checkpoints) > 1:\n",
+    "            checkpoints.sort()\n",
+    "            for checkpoint in checkpoints[:-1]:\n",
+    "                os.remove(os.path.join(base_dir, checkpoint))\n",
+    "\n",
+    "es = EarlyStopping(patience=early_stopping_patience, restore_best_weights=True)\n",
+    "\n",
+    "mcp = CustomModelCheckpoint(\n",
+    "    filepath=checkpoint_filepath,\n",
+    "    save_weights_only=True,\n",
+    "    monitor='val_loss',\n",
+    "    save_best_only=True,\n",
+    "    save_freq='epoch',\n",
+    "    verbose=1\n",
+    ")\n",
+    "\n",
+    "csv_logger = CSVLogger(f'{base_dir}/training_log.csv', append=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0d3ecb0d-5db2-4610-bd58-e55d06f049a6",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 1/1000\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-05-12 14:50:58.231869: I external/local_xla/xla/stream_executor/cuda/cuda_dnn.cc:454] Loaded cuDNN version 8907\n",
+      "2025-05-12 14:50:59.198883: I external/local_tsl/tsl/platform/default/subprocess.cc:304] Start cannot spawn child process: No such file or directory\n",
+      "2025-05-12 14:51:00.095126: I tensorflow/core/util/cuda_solvers.cc:179] Creating GpuSolver handles for stream 0x7f16107c8c00\n",
+      "2025-05-12 14:51:02.649529: I external/local_xla/xla/service/service.cc:168] XLA service 0x7f08856732b0 initialized for platform CUDA (this does not guarantee that XLA will be used). Devices:\n",
+      "2025-05-12 14:51:02.649607: I external/local_xla/xla/service/service.cc:176]   StreamExecutor device (0): NVIDIA A100-PCIE-40GB MIG 1g.5gb, Compute Capability 8.0\n",
+      "2025-05-12 14:51:02.660181: I tensorflow/compiler/mlir/tensorflow/utils/dump_mlir_util.cc:269] disabling MLIR crash reproducer, set env var `MLIR_CRASH_REPRODUCER_DIRECTORY` to enable.\n",
+      "WARNING: All log messages before absl::InitializeLog() is called are written to STDERR\n",
+      "I0000 00:00:1747054262.890311 2034880 device_compiler.h:186] Compiled cluster using XLA!  This line is logged at most once for the lifetime of the process.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "215/294 [====================>.........] - ETA: 22s - loss: 40519.5859"
+     ]
+    }
+   ],
+   "source": [
+    "history = model.fit(\n",
+    "        x=training_generator,\n",
+    "        validation_data=validation_generator,\n",
+    "        callbacks=[es, mcp, csv_logger],\n",
+    "        epochs=1000,\n",
+    "        shuffle=False,\n",
+    "        verbose=1\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "23aca72a-2c3c-4d21-bff7-5f6ce83b3eed",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO:\n",
+    "# Pre-train the model first\n",
+    "# Then do the KL div trainings\n",
+    "\n",
+    "# NVM combined training is working out"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5f146386-fe91-4d43-ad0f-e10bbcfc2bfc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "1+1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fe4e2706-3e27-4ece-9ebd-be135f6bbcb6",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python3 kernel (default)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Updated DataGenerator in  `OptimizedDataGeneratorNew.py` now supports loading the new shuffled datasets. The new generator is designed to be a drop-in replacement for the previous one, with only minor changes needed (e.g., updated `train` and `val` `file_size` settings).

See `train_model_new_example.ipynb` for example usage.