### PR TITLE
Debugged: with reset index: True

### DIFF
--- a/OptimizedDataGeneratorNew.py
+++ b/OptimizedDataGeneratorNew.py
@@ -18,6 +18,7 @@ from qkeras import quantized_bits
 import utils
 
 
+
 # custom quantizer
 
 # @tf.function
@@ -267,7 +268,7 @@ class OptimizedDataGenerator(tf.keras.utils.Sequence):
             parquet_file = self.files[file_idx]
 
             all_columns_to_read = self.recon_cols + self.labels_list
-            df = pd.read_parquet(parquet_file, columns=all_columns_to_read)
+            df = pd.read_parquet(parquet_file, columns=all_columns_to_read).reset_index(drop=True) 
 
             # df = pd.read_parquet(parquet_file, columns=self.use_time_stamps)
             recon_df, labels_df = split_df_to_X_y_df(df, self.input_shape, self.labels_list, self.recon_cols)


### PR DESCRIPTION
Added `.reset_index(drop=True)` after reading the parquet file to ensure consistent row alignment between recons and labels, especially when shuffling is applied. 
Confirmed fix with `dataset_2s_50x12P5_parquets`; model now converges correctly.