### PR TITLE
Memory leak fix

### DIFF
--- a/OptimizedDataGenerator_v2.py
+++ b/OptimizedDataGenerator_v2.py
@@ -163,6 +163,13 @@ class OptimizedDataGenerator(tf.keras.utils.Sequence):
             
         self.tfrecord_filenames = np.sort(np.array(tf.io.gfile.glob(os.path.join(self.tfrecords_dir, "*.tfrecord"))))
         self.quantize = quantize
+        #Make the TFRDatasets once upon initialization and iterate in __getitem__
+        self.datasets = [
+            tf.data.TFRecordDataset(path)
+              .map(self._parse_tfrecord_fn)
+            for path in self.tfrecord_filenames
+        ]
+        
         self.epoch_count = 0
         self.on_epoch_end()
 
@@ -595,13 +602,9 @@ class OptimizedDataGenerator(tf.keras.utils.Sequence):
         shuffling is also done here.
         TODO: prefetching (un-done)
         """
-        tfrecord_path = self.tfrecord_filenames[batch_index]
-        raw_dataset = tf.data.TFRecordDataset(tfrecord_path)
-        parsed_dataset = raw_dataset.map(self._parse_tfrecord_fn, num_parallel_calls=tf.data.AUTOTUNE)
-
         # Get the first (and only) batch from the dataset
         try:
-            X_batch, y_batch = next(iter(parsed_dataset))
+            X_batch, y_batch = next(iter(self.datasets[batch_index]))
         except StopIteration:
             raise ValueError(f"No data found in TFRecord file: {tfrecord_path}")
 
@@ -617,7 +620,6 @@ class OptimizedDataGenerator(tf.keras.utils.Sequence):
             X_batch = tf.gather(X_batch, shuffled_indices)
             y_batch = tf.gather(y_batch, shuffled_indices)
 
-        del raw_dataset, parsed_dataset
         return X_batch, y_batch
             
     @staticmethod

--- a/OptimizedDataGenerator_v3.py
+++ b/OptimizedDataGenerator_v3.py
@@ -186,6 +186,12 @@ class OptimizedDataGenerator(tf.keras.utils.Sequence):
         self.tfrecord_filenames = np.sort(np.array(tf.io.gfile.glob(os.path.join(self.tfrecords_dir, "*.tfrecord"))))
         self.quantize = quantize
         self.noise = noise
+        #Make the TFRDatasets once upon initialization and iterate in __getitem__
+        self.datasets = [
+            tf.data.TFRecordDataset(path)
+              .map(self._parse_tfrecord_fn)
+            for path in self.tfrecord_filenames
+        ]
 
         # manual 2-bit digitization (FOR LOADING TFRecords ONLY!)
         self.digitize = digitize
@@ -669,13 +675,10 @@ class OptimizedDataGenerator(tf.keras.utils.Sequence):
         shuffling is also done here.
         TODO: prefetching (un-done)
         """
-        tfrecord_path = self.tfrecord_filenames[batch_index]
-        raw_dataset = tf.data.TFRecordDataset(tfrecord_path)
-        parsed_dataset = raw_dataset.map(self._parse_tfrecord_fn, num_parallel_calls=tf.data.AUTOTUNE)
 
         # Get the first (and only) batch from the dataset
         try:
-            X_batch, y_batch = next(iter(parsed_dataset))
+            X_batch, y_batch = next(iter(self.datasets[batch_index]))
         except StopIteration:
             raise ValueError(f"No data found in TFRecord file: {tfrecord_path}")
 
@@ -699,7 +702,6 @@ class OptimizedDataGenerator(tf.keras.utils.Sequence):
             X_batch = tf.gather(X_batch, shuffled_indices)
             y_batch = tf.gather(y_batch, shuffled_indices)
 
-        del raw_dataset, parsed_dataset
         return X_batch, y_batch
             
     @staticmethod


### PR DESCRIPTION
DataGenerators were filling up memory by creating new TFR objects at every batch call. This fix creates the objects upon initialization and iterates through them instead. 